### PR TITLE
Add eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,21 @@
+{
+    "extends": ["eslint:recommended"],
+    "plugins": ["react"],
+    "parser": "babel-eslint",
+    "rules": {
+        "no-console": "off",
+        "react/jsx-uses-react": "error",
+        "react/jsx-uses-vars": "error"
+    },
+    "env": {
+      "es6": true,
+      "browser": true,
+      "node": true
+    },
+    "settings": {
+        "react": {
+            "version": "detect"
+        }
+    }
+  }
+  

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-    "tabWidth": 4,
-    "singleQuote": true,
-    "printWidth": 120
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4663,6 +4663,7 @@
       "version": "2.18.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
       "integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
+      "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
         "contains-path": "^0.1.0",
@@ -4681,6 +4682,7 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
           "requires": {
             "esutils": "^2.0.2",
             "isarray": "^1.0.0"
@@ -4692,6 +4694,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
       "integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.5",
         "aria-query": "^3.0.0",
@@ -4708,6 +4711,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz",
       "integrity": "sha512-GacBAATewhhptbK3/vTP09CbFrgUJmBSaaRcWdbQLFvUZy9yVcQxigBNHGPU/KE2AyHpzj3AWXpxoMTsIDiHug==",
+      "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
         "doctrine": "^2.1.0",
@@ -4724,6 +4728,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
           "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
           "requires": {
             "esutils": "^2.0.2"
           }
@@ -8916,6 +8921,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
       "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.12.0",
@@ -10236,12 +10242,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
-    },
-    "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
-      "dev": true
     },
     "pretty-bytes": {
       "version": "5.3.0",
@@ -13309,11 +13309,6 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
-    },
-    "xdate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/xdate/-/xdate-0.8.2.tgz",
-      "integrity": "sha1-17AzwASF0CaVuvAET06s2j/JYaM="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -3,22 +3,22 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "eslint-plugin-import": "^2.18.2",
-    "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-react": "^7.16.0",
     "lodash": "^4.17.15",
     "react": "^16.10.1",
     "react-dom": "^16.10.1",
-    "react-scripts": "3.0.1",
-    "xdate": "^0.8.2"
+    "react-scripts": "3.0.1"
   },
   "devDependencies": {
-    "prettier": "1.18.2",
+    "eslint": "5.16.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-react": "^7.16.0",
     "prop-types": "15.7.2"
   },
   "scripts": {
-    "start": "NODE_PATH=src/lib:src PORT=3001 react-scripts start",
+    "start": "NODE_PATH=src PORT=3002 react-scripts start",
     "build": "react-scripts build",
+    "lint": "eslint src",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,0 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
-
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
-});


### PR DESCRIPTION
Only add the `eslint:recommended` config because we want to help candidates spot typos and common errors, not be opinionated about how they write the code or be distracting.

Also removed `App.test` since we probably don't need tests at all.